### PR TITLE
use job specific env vars

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,7 +25,9 @@ jobs:
       - name: packer validate
         run: |
           pushd src
-          packer validate -var ImageName=${{ github.event.repository.name }}-${{ github.ref_name }}} template.json
+          echo "${{ github.event.repository.name }}"
+          echo "${{ github.ref_name }}"
+          packer validate -var ImageName=${{ github.event.repository.name }}-${{ github.ref_name }} template.json
   deploy:
     name: Deploy to AWS org-sagebase-imagecentral
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,12 +7,6 @@ on:
   pull_request:
     branches: [ '*' ]
 
-env:
-  PACKER_PRODUCT_VERSION: "latest"
-  IMAGE_NAME: "${{ github.event.repository.name }}-${{ github.ref_name }}"
-  AWS_ROLE_TO_ASSUME: "arn:aws:iam::867686887310:role/sagebase-github-oidc-packer-image-deploy"
-  AWS_REGION: "us-east-1"
-
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -27,11 +21,11 @@ jobs:
         uses: hashicorp/setup-packer@main
         id: setup
         with:
-          version: ${{ env.PACKER_PRODUCT_VERSION }}
+          version: latest
       - name: packer validate
         run: |
           pushd src
-          packer validate -var ImageName=${{ env.IMAGE_NAME }} template.json
+          packer validate -var ImageName=${{ github.event.repository.name }}-${{ github.ref_name }}} template.json
   deploy:
     name: Deploy to AWS org-sagebase-imagecentral
     runs-on: ubuntu-latest
@@ -40,6 +34,9 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      AWS_ROLE_TO_ASSUME: "arn:aws:iam::867686887310:role/sagebase-github-oidc-packer-image-deploy"
+      AWS_REGION: "us-east-1"
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,7 +19,6 @@ jobs:
       - uses: pre-commit/action@v3.0.0
       - name: Setup `packer`
         uses: hashicorp/setup-packer@main
-        id: setup
         with:
           version: latest
       - name: packer validate
@@ -27,7 +26,7 @@ jobs:
           pushd src
           echo "${{ github.event.repository.name }}"
           echo "${{ github.ref_name }}"
-          packer validate -var ImageName=${{ github.event.repository.name }}-${{ github.ref_name }} template.json
+          packer validate -var ImageName=validate template.json
   deploy:
     name: Deploy to AWS org-sagebase-imagecentral
     runs-on: ubuntu-latest
@@ -44,9 +43,8 @@ jobs:
       uses: actions/checkout@v3
     - name: Setup `packer`
       uses: hashicorp/setup-packer@main
-      id: setup
       with:
-        version: ${{ env.PACKER_PRODUCT_VERSION }}
+        version: "latest"
     - name: Assume AWS Role
       uses: aws-actions/configure-aws-credentials@v2
       with:
@@ -57,4 +55,4 @@ jobs:
     - name: Build and Upload AMI
       run: |
         pushd src
-        packer build -force -var AwsRoleArn=${{ env.AWS_ROLE_TO_ASSUME }} -var AwsRegion=${{ env.AWS_REGION }} -var ImageName=${{ env.IMAGE_NAME }} template.json
+        packer build -force -var AwsRoleArn=${{ env.AWS_ROLE_TO_ASSUME }} -var AwsRegion=${{ env.AWS_REGION }} -var ImageName=${{ github.event.repository.name }}-${{ github.ref_name }} template.json


### PR DESCRIPTION
Using global vars fails for Bild and Upload AMI job we switch to specifying env vars at the job level.
