### PR TITLE
Fix ansible failed to handshake error

### DIFF
--- a/src/template.json
+++ b/src/template.json
@@ -53,11 +53,9 @@
   ],
   "provisioners": [
     {
-      "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS='-o IdentitiesOnly=yes'"
-      ],
       "extra_arguments": [
-        "-v",
+        "--ssh-extra-args",
+        "-o IdentitiesOnly=yes -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa",
         "--scp-extra-args",
         "'-O'"
       ],


### PR DESCRIPTION
Setup a workaround[1] for this ansible error:
```
==> amazon-ebs: failed to handshake
    amazon-ebs: fatal: [default]: UNREACHABLE! =>
{"changed": false, "msg": "Failed to connect to the host via ssh:
Unable to negotiate with 127.0.0.1 port 44539: no matching host key type found.
Their offer: ssh-rsa", "unreachable": true}
```

[1] https://github.com/hashicorp/packer-plugin-ansible/issues/69

